### PR TITLE
Remove default Salesforce versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,6 +348,19 @@ The proxy argument is the same as what requests uses, a map of scheme to proxy U
 
 All results are returned as JSON converted OrderedDict to preserve order of keys from REST responses.
 
+Run Tests
+---------
+1. Create a `virtualenv`:
+    $ pip install virtualenv
+    $ virtualenv venv
+    $ source venv/bin/activate
+2. Install `tox`:
+    $ pip install tox
+3. Run Tests:
+    $ tox
+4. Close virtual environment:
+    $ deactivate
+
 Authors & License
 -----------------
 

--- a/simple_salesforce/api.py
+++ b/simple_salesforce/api.py
@@ -1,14 +1,10 @@
 """Core classes and exceptions for Simple-Salesforce"""
 
-
-# has to be defined prior to login import
-DEFAULT_API_VERSION = '39.0'
-
-
+import json
 import logging
 import warnings
+
 import requests
-import json
 
 try:
     from urlparse import urlparse, urljoin
@@ -51,9 +47,9 @@ class Salesforce(object):
     """
     # pylint: disable=too-many-arguments
     def __init__(
-            self, username=None, password=None, security_token=None,
+            self, version, username=None, password=None, security_token=None,
             session_id=None, instance=None, instance_url=None,
-            organizationId=None, sandbox=False, version=DEFAULT_API_VERSION,
+            organizationId=None, sandbox=False,
             proxies=None, session=None, client_id=None):
         """Initialize the instance with the given parameters.
 
@@ -112,12 +108,12 @@ class Salesforce(object):
 
             # Pass along the username/password to our login helper
             self.session_id, self.sf_instance = SalesforceLogin(
+                sf_version=self.sf_version,
                 session=self.session,
                 username=username,
                 password=password,
                 security_token=security_token,
                 sandbox=self.sandbox,
-                sf_version=self.sf_version,
                 proxies=self.proxies,
                 client_id=client_id)
 
@@ -139,12 +135,12 @@ class Salesforce(object):
 
             # Pass along the username/password to our login helper
             self.session_id, self.sf_instance = SalesforceLogin(
+                sf_version=self.sf_version,
                 session=self.session,
                 username=username,
                 password=password,
                 organizationId=organizationId,
                 sandbox=self.sandbox,
-                sf_version=self.sf_version,
                 proxies=self.proxies,
                 client_id=client_id)
 
@@ -465,8 +461,7 @@ class SFType(object):
 
     # pylint: disable=too-many-arguments
     def __init__(
-            self, object_name, session_id, sf_instance,
-            sf_version=DEFAULT_API_VERSION, proxies=None, session=None):
+            self, object_name, session_id, sf_instance, sf_version, proxies=None, session=None):
         """Initialize the instance with the given parameters.
 
         Arguments:
@@ -759,8 +754,7 @@ class SalesforceAPI(Salesforce):
 
     """
     # pylint: disable=too-many-arguments
-    def __init__(self, username, password, security_token, sandbox=False,
-                 sf_version='39.0'):
+    def __init__(self, username, password, security_token, sf_version, sandbox=False):
         """Initialize the instance with the given parameters.
 
         Arguments:
@@ -778,8 +772,8 @@ class SalesforceAPI(Salesforce):
             DeprecationWarning
         )
 
-        super(SalesforceAPI, self).__init__(username=username,
+        super(SalesforceAPI, self).__init__(version=sf_version,
+                                            username=username,
                                             password=password,
                                             security_token=security_token,
-                                            sandbox=sandbox,
-                                            version=sf_version)
+                                            sandbox=sandbox)

--- a/simple_salesforce/login.py
+++ b/simple_salesforce/login.py
@@ -5,10 +5,8 @@ Heavily Modified from RestForce 1.0.0
 
 DEFAULT_CLIENT_ID_PREFIX = 'RestForce'
 
-
-from simple_salesforce.api import DEFAULT_API_VERSION
-from simple_salesforce.util import getUniqueElementValueFromXmlString
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
+from simple_salesforce.util import getUniqueElementValueFromXmlString
 
 try:
     # Python 3+
@@ -20,9 +18,8 @@ import requests
 
 # pylint: disable=invalid-name,too-many-arguments,too-many-locals
 def SalesforceLogin(
-        username=None, password=None, security_token=None,
-        organizationId=None, sandbox=False, sf_version=DEFAULT_API_VERSION,
-        proxies=None, session=None, client_id=None, hostname=None):
+        sf_version, username=None, password=None, security_token=None,
+        organizationId=None, sandbox=False, proxies=None, session=None, client_id=None, hostname=None):
     """Return a tuple of `(session_id, sf_instance)` where `session_id` is the
     session ID to use for authentication to Salesforce and `sf_instance` is
     the domain of the instance of Salesforce to use for the session.

--- a/simple_salesforce/tests/test_api.py
+++ b/simple_salesforce/tests/test_api.py
@@ -1,7 +1,9 @@
 """Tests for api.py"""
 
 import re
+
 from datetime import datetime
+
 try:
     # Python 2.6
     import unittest2 as unittest
@@ -27,7 +29,7 @@ from simple_salesforce.api import (
     SFType
 )
 
-
+SALESFORCE_API_VERSION = "51.0"
 
 def _create_sf_type(
     object_name='Case',
@@ -39,6 +41,7 @@ def _create_sf_type(
         object_name=object_name,
         session_id=session_id,
         sf_instance=sf_instance,
+        sf_version=SALESFORCE_API_VERSION,
         session=requests.Session()
     )
 
@@ -485,6 +488,7 @@ class TestSalesforce(unittest.TestCase):
             'response': on_response,
         }
         client = Salesforce(
+            version=SALESFORCE_API_VERSION,
             session=session,
             username='foo@bar.com',
             password='password',
@@ -506,16 +510,17 @@ class TestSalesforce(unittest.TestCase):
         # Use an invalid version that is guaranteed to never be used
         expected_version = '4.2'
         client = Salesforce(
+            version=expected_version,
             session=requests.Session(), username='foo@bar.com',
-            password='password', security_token='token',
-            version=expected_version)
+            password='password', security_token='token')
 
         self.assertEqual(
             client.base_url.split('/')[-2], 'v%s' % expected_version)
 
     def test_shared_session_to_sftype(self):
         """Test Salesforce and SFType instances share default `Session`"""
-        client = Salesforce(session_id=tests.SESSION_ID,
+        client = Salesforce(version=SALESFORCE_API_VERSION,
+                            session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL)
 
         self.assertIs(client.session, client.Contact.session)
@@ -523,7 +528,8 @@ class TestSalesforce(unittest.TestCase):
     def test_shared_custom_session_to_sftype(self):
         """Test Salesforce and SFType instances share custom `Session`"""
         session = requests.Session()
-        client = Salesforce(session_id=tests.SESSION_ID,
+        client = Salesforce(version=SALESFORCE_API_VERSION,
+                            session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL,
                             session=session)
 
@@ -533,7 +539,8 @@ class TestSalesforce(unittest.TestCase):
     def test_proxies_inherited_default(self):
         """Test Salesforce and SFType use same proxies"""
         session = requests.Session()
-        client = Salesforce(session_id=tests.SESSION_ID,
+        client = Salesforce(version=SALESFORCE_API_VERSION,
+                            session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL,
                             session=session)
 
@@ -544,7 +551,8 @@ class TestSalesforce(unittest.TestCase):
         """Test Salesforce and SFType use same custom proxies"""
         session = requests.Session()
         session.proxies = tests.PROXIES
-        client = Salesforce(session_id=tests.SESSION_ID,
+        client = Salesforce(version=SALESFORCE_API_VERSION,
+                            session_id=tests.SESSION_ID,
                             instance_url=tests.SERVER_URL,
                             session=session)
         self.assertIs(tests.PROXIES, client.session.proxies)
@@ -556,7 +564,7 @@ class TestSalesforce(unittest.TestCase):
         session.proxies = tests.PROXIES
 
         with patch('simple_salesforce.api.logger.warning') as mock_log:
-            client = Salesforce(session_id=tests.SESSION_ID,
+            client = Salesforce(version=SALESFORCE_API_VERSION, session_id=tests.SESSION_ID,
                 instance_url=tests.SERVER_URL, session=session, proxies={})
             self.assertIn('ignoring proxies', mock_log.call_args[0][0])
             self.assertIs(tests.PROXIES, client.session.proxies)

--- a/simple_salesforce/tests/test_login.py
+++ b/simple_salesforce/tests/test_login.py
@@ -23,6 +23,7 @@ from simple_salesforce import tests
 from simple_salesforce.login import SalesforceLogin
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed
 
+SALESFORCE_API_VERSION = "51.0"
 
 class TestSalesforceLogin(unittest.TestCase):
     """Tests for the SalesforceLogin function"""
@@ -54,6 +55,7 @@ class TestSalesforceLogin(unittest.TestCase):
             'response': on_response,
         }
         session_id, instance = SalesforceLogin(
+            sf_version=SALESFORCE_API_VERSION,
             session=session,
             username='foo@bar.com',
             password='password',
@@ -72,6 +74,7 @@ class TestSalesforceLogin(unittest.TestCase):
 
         with self.assertRaises(SalesforceAuthenticationFailed):
             SalesforceLogin(
+                sf_version=SALESFORCE_API_VERSION,
                 username='myemail@example.com.sandbox',
                 password='password',
                 security_token='token',


### PR DESCRIPTION
There are a number of different places that a default Salesforce version is defined across [etleap/salesforce-extractor](https://github.com/etleap/salesforce-extractor), [simple-salesforce](https://github.com/etleap/simple-salesforce), [salesforce-bulk](https://github.com/etleap/salesforce-bulk), which makes it hard to be sure which version is being used.

This change removes the default versions from this repo and makes the parameter required so the version in use is clearly only defined in one place.

Change made when doing the Salesforce upgrade: https://github.com/etleap/salesforce-extractor/pull/44